### PR TITLE
Add support for Pairing command

### DIFF
--- a/src/ClientMessage.cs
+++ b/src/ClientMessage.cs
@@ -23,6 +23,9 @@ internal enum MeetingAction
     [JsonPropertyName("none")]
     None = 0,
 
+    [JsonPropertyName("pair")]
+    Pair = 0b0000_0001_0000_0001,
+
     [JsonPropertyName("query-state")]
     QueryMeetingState = 0b0000_0001_0000_0000,
 


### PR DESCRIPTION
Supports the 'pair' command in new Teams, which triggers the popup for permission and starts generating tokens. (See issue #5)

Also adds support for running on MacOS